### PR TITLE
Fix merging of routes for subclasses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,12 @@
         "psr-0": {
             "JMS": "src/"
         }
+    },
+
+    "autoload-dev": {
+        "psr-0": {
+            "JMS\\Tests": "tests/"
+        }
     }
+
 }

--- a/src/JMS/ObjectRouting/Metadata/ClassMetadata.php
+++ b/src/JMS/ObjectRouting/Metadata/ClassMetadata.php
@@ -19,6 +19,7 @@
 namespace JMS\ObjectRouting\Metadata;
 
 use Metadata\MergeableClassMetadata;
+use Metadata\MergeableInterface;
 
 class ClassMetadata extends MergeableClassMetadata
 {
@@ -30,6 +31,12 @@ class ClassMetadata extends MergeableClassMetadata
             'name' => $name,
             'params' => $params,
         );
+    }
+
+    public function merge(MergeableInterface $object)
+    {
+        parent::merge($object);
+        $this->routes = array_merge($this->routes, $object->routes);
     }
 
     public function serialize()

--- a/tests/JMS/Tests/ObjectRouting/Metadata/ClassMetadataTest.php
+++ b/tests/JMS/Tests/ObjectRouting/Metadata/ClassMetadataTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace JMS\Tests\ObjectRouting\Metadata;
+
+use JMS\ObjectRouting\Metadata\ClassMetadata;
+
+class ClassMetadataTest extends \PHPUnit_Framework_TestCase
+{
+    public function testMerge()
+    {
+        $base = new ClassMetadata(\PHPUnit_Framework_TestCase::class);
+        $base->addRoute('test', 'base-route');
+
+        $merged = new ClassMetadata(self::class);
+        $merged->addRoute('test', 'merged-route');
+
+        $base->merge($merged);
+
+        $this->assertEquals(self::class, $base->name);
+        $this->assertEquals(['test' => ['name' => 'merged-route', 'params' => []]], $base->routes);
+    }
+}

--- a/tests/JMS/Tests/ObjectRouting/ObjectRouterTest.php
+++ b/tests/JMS/Tests/ObjectRouting/ObjectRouterTest.php
@@ -84,8 +84,8 @@ class ObjectRouterTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->router = new ObjectRouter(
-            $this->adapter = $this->getMock('JMS\ObjectRouting\RouterInterface'),
-            $this->factory = $this->getMock('Metadata\MetadataFactoryInterface')
+            $this->adapter = $this->createMock('JMS\ObjectRouting\RouterInterface'),
+            $this->factory = $this->createMock('Metadata\MetadataFactoryInterface')
         );
     }
 }

--- a/tests/JMS/Tests/ObjectRouting/Symfony/Symfony22AdapterTest.php
+++ b/tests/JMS/Tests/ObjectRouting/Symfony/Symfony22AdapterTest.php
@@ -24,7 +24,7 @@ class Symfony22AdapterTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->adapter = new Symfony22Adapter(
-            $this->router = $this->getMock('Symfony\Component\Routing\RouterInterface')
+            $this->router = $this->createMock('Symfony\Component\Routing\RouterInterface')
         );
     }
 }


### PR DESCRIPTION
This fixes that `@ObjectRoute` annotations from subclasses would not correctly override the route definitions from base classes.

Fixes https://github.com/schmittjoh/object-routing/issues/3.
