### PR TITLE
Skip parsing attributes for PHP < 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,13 +9,14 @@
 
     "require": {
         "php": "^7.4|8.0.*|8.1.*",
+        "doctrine/annotations": "^1.12",
         "jms/metadata": "^2.6.1",
-        "symfony/property-access": "^2.2|^3.0|^4.0|^5.0"
+        "symfony/property-access": "^3.4|^4.0|^5.0"
     },
 
     "require-dev": {
         "doctrine/common": "^2.2",
-        "phpunit/phpunit": "^8.0|^9.0",
+        "phpunit/phpunit": "^8.5.26|^9.0",
         "symfony/routing": "^2.2|^3.0|^4.0",
         "symfony/yaml": "^3.0|^4.0|^5.0",
         "twig/twig": "^2.0|^3.0"

--- a/src/JMS/ObjectRouting/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/ObjectRouting/Metadata/Driver/AnnotationDriver.php
@@ -50,9 +50,12 @@ class AnnotationDriver implements DriverInterface
     private function buildAnnotations(\ReflectionClass $class): array
     {
         $annots = [];
-        foreach ($class->getAttributes() as $attr) {
-            if (str_starts_with($attr->getName(), 'JMS\\ObjectRouting\\Annotation\\')) {
-                $annots[] = $attr->newInstance();
+
+        if (PHP_MAJOR_VERSION >= 8) {
+            foreach ($class->getAttributes() as $attr) {
+                if (str_starts_with($attr->getName(), 'JMS\\ObjectRouting\\Annotation\\')) {
+                    $annots[] = $attr->newInstance();
+                }
             }
         }
 

--- a/tests/JMS/Tests/ObjectRouting/Metadata/Driver/AnnotationDriverTest.php
+++ b/tests/JMS/Tests/ObjectRouting/Metadata/Driver/AnnotationDriverTest.php
@@ -4,6 +4,7 @@ namespace JMS\Tests\ObjectRouting\Metadata\Driver;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\ObjectRouting\Metadata\Driver\AnnotationDriver;
+use JMS\Tests\ObjectRouting\Metadata\Driver\Fixture\BlogPost;
 use PHPUnit\Framework\TestCase;
 
 class AnnotationDriverTest extends TestCase
@@ -13,7 +14,7 @@ class AnnotationDriverTest extends TestCase
 
     public function testLoad()
     {
-        $metadata = $this->driver->loadMetadataForClass(new \ReflectionClass('JMS\Tests\ObjectRouting\Metadata\Driver\Fixture\BlogPost'));
+        $metadata = $this->driver->loadMetadataForClass(new \ReflectionClass(BlogPost::class));
         $this->assertCount(2, $metadata->routes);
 
         $routes = array(

--- a/tests/JMS/Tests/ObjectRouting/Metadata/Driver/AnnotationDriverTest.php
+++ b/tests/JMS/Tests/ObjectRouting/Metadata/Driver/AnnotationDriverTest.php
@@ -8,13 +8,6 @@ use PHPUnit\Framework\TestCase;
 
 class AnnotationDriverTest extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        if (PHP_MAJOR_VERSION < 8) {
-            self::markTestSkipped(AnnotationDriver::class . ' is only supported for PHP ^8.0');
-        }
-    }
-
     /** @var AnnotationDriver */
     private $driver;
 


### PR DESCRIPTION
`ReflectionClass::getAttributes()` isn't available before PHP 8, so skip parsing attributes before that version.

Since the `AnnotationDriver` is also used for annotation-based parsing, we need not only skip the test, but instead skip _attibute_ parsing in the code.

Running a skipped test again revealed some more errors for the minimum requirements specified previously.