### PR TITLE
Add return type hints

### DIFF
--- a/src/JMS/ObjectRouting/Metadata/ClassMetadata.php
+++ b/src/JMS/ObjectRouting/Metadata/ClassMetadata.php
@@ -39,7 +39,7 @@ class ClassMetadata extends MergeableClassMetadata
         $this->routes = array_merge($this->routes, $object->routes);
     }
 
-    public function serialize()
+    public function serialize(): string
     {
         return serialize(
             array(
@@ -49,7 +49,7 @@ class ClassMetadata extends MergeableClassMetadata
         );
     }
 
-    public function unserialize($str)
+    public function unserialize($str): void
     {
         list(
             $this->routes,

--- a/src/JMS/ObjectRouting/Twig/RoutingExtension.php
+++ b/src/JMS/ObjectRouting/Twig/RoutingExtension.php
@@ -15,7 +15,7 @@ class RoutingExtension extends AbstractExtension
         $this->router = $router;
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('object_path', [$this, 'path']),
@@ -23,12 +23,12 @@ class RoutingExtension extends AbstractExtension
         ];
     }
 
-    public function url($type, $object, array $extraParams = [])
+    public function url($type, $object, array $extraParams = []): string
     {
         return $this->router->generate($type, $object, true, $extraParams);
     }
 
-    public function path($type, $object, array $extraParams = [])
+    public function path($type, $object, array $extraParams = []): string
     {
         return $this->router->generate($type, $object, false, $extraParams);
     }


### PR DESCRIPTION
This adds a few return type hints to address deprecation notices and be forwards-compatible with future Symfony versions.

These changes are compatible even with PHP 7.2.